### PR TITLE
Support org-agenda-files with directories

### DIFF
--- a/org-ql.el
+++ b/org-ql.el
@@ -58,7 +58,7 @@ buffer (the default is to widen and search the entire buffer)."
   (setq buffers-or-files (cl-typecase buffers-or-files
                            (null (list (current-buffer)))
                            (buffer (list buffers-or-files))
-                           (list buffers-or-files)
+                           (list (org-ql--expand-directories buffers-or-files))
                            (string (list buffers-or-files))))
   (let* ((org-use-tag-inheritance t)
          (org-scanner-tags nil)
@@ -71,6 +71,17 @@ buffer (the default is to widen and search the entire buffer)."
                            (mapcar action-fn
                                    (org-ql--filter-buffer :pred pred :narrow narrow)))
                          buffers-or-files))))
+
+(defun org-ql--expand-directories (buffers-or-files)
+  "If BUFFERS-OR-FILES contain directories, expand Org files in them."
+  (-flatten-n 1
+              (mapcar
+               (lambda (it)
+                 (if (and (stringp it)
+                          (file-directory-p it))
+                     (directory-files it t org-agenda-file-regexp)
+                   it))
+               buffers-or-files)))
 
 (cl-defun org-ql--filter-buffer (&key pred narrow)
   "Return positions of matching headings in current buffer.


### PR DESCRIPTION
According to the spec, `org-agenda-files` variable can contain directories. If the agenda files contains a directory, `org-ql` does not work properly on `org-agenda-files`, because the query is run on a buffer which is not in org-mode.

To support `org-agenda-files` with directories, I changed the following line

https://github.com/alphapapa/org-agenda-ng/blob/master/org-ql.el#L63

into

```emacs-lisp
(list (org-ql--expand-directories buffers-or-files))
```

and added the following function:

```emacs-lisp
(defun org-ql--expand-directories (buffers-or-files)
  "If BUFFERS-OR-FILES contain directories, expand Org files in them."
  (-flatten-n 1
              (mapcar
               (lambda (it)
                 (if (and (stringp it)
                          (file-directory-p it))
                     (directory-files it t org-agenda-file-regexp)
                   it))
               buffers-or-files)))
```

However, this still doesn't seem to work. Could you identify what's wrong with this solution? 